### PR TITLE
Optimize the number of jobs running

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,10 @@
 name: CI
 
 on:
-- push
-- pull_request
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 jobs:
   test:


### PR DESCRIPTION
Run only on PR or push to main branch. This makes the views of checks easier to navigate as there are no duplicates. (There is also small speed improvement.)