### PR TITLE
Formatting: Avoid trailing comma

### DIFF
--- a/activities/activity_luke_allen.py
+++ b/activities/activity_luke_allen.py
@@ -44,7 +44,7 @@ def run_sim_wave(scanned_elev, env, **kwargs):
         env=env,
     )
     gs.run_command(
-        "r.contour", input="pres", output="contours", step=interval, flags="t", env=env,
+        "r.contour", input="pres", output="contours", step=interval, flags="t", env=env
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[tool.black]
+line-length = 88
+target-version = ['py36', 'py37', 'py38']
+include = '\.pyi?$'
+exclude = '''
+(
+    # exclude directories in the root of the project
+    /(
+          \.eggs
+        | \.git
+        | \.hg
+        | \.mypy_cache
+        | \.tox
+        | \.venv
+        | _build
+        | buck-out
+        | build
+        | bin\.
+        | dist\.
+    )/
+)
+'''

--- a/tests/functions.py
+++ b/tests/functions.py
@@ -47,7 +47,7 @@ class TestFunctionsInFiles(unittest.TestCase):
                 [self.executable, self.mapset_path, "--exec", self.python, full_path]
             )
             self.assertEqual(
-                return_code, 0, msg=("Running {filename} failed".format(**locals())),
+                return_code, 0, msg=("Running {filename} failed".format(**locals()))
             )
             return_code = subprocess.call(
                 [self.executable, self.mapset_path, "--exec", self.python, full_path]

--- a/website/render_activities.py
+++ b/website/render_activities.py
@@ -81,9 +81,7 @@ class GrassRunner:
 
     def run_env(self, env, args):
         """Run a command with environmental variables provided in env"""
-        subprocess.check_call(
-            [self.executable, self.mapset, "--exec"] + args, env=env,
-        )
+        subprocess.check_call([self.executable, self.mapset, "--exec"] + args, env=env)
 
     def run(self, *args):
         """Run a command"""


### PR DESCRIPTION
The trailing comma behavior changed in between Black versions.
Removing trailing commas where 20.8b1 interprets them as an instruction
to use line-by-line format.

Add pyproject file with Black settings to ensure correct Python version targeting.